### PR TITLE
fix(release): guard publish steps with success() check

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,13 +53,13 @@ jobs:
         run: npm run package
 
       - name: Publish to VS Code Marketplace
-        if: inputs.registry != 'ovsx'
+        if: success() && inputs.registry != 'ovsx'
         run: npm run release:marketplace
         env:
           VSCE_PAT: ${{ secrets.VSCE_PAT }}
 
       - name: Publish to Open VSX Registry
-        if: inputs.registry != 'marketplace'
+        if: success() && inputs.registry != 'marketplace'
         run: npm run release:ovsx
         env:
           OPEN_VSX_TOKEN: ${{ secrets.OPEN_VSX_TOKEN }}


### PR DESCRIPTION
Explicit if conditions replace GitHub Actions' implicit success() guard. Without it, a publish step with only inputs.registry != 'ovsx' would run even if tests or packaging failed.